### PR TITLE
Fixes internal server error

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,11 @@ def my_form_post():
 
 
 def defn(name):
+    # Checks to see if there is a string with no blanks
+    if len(name.strip()) == 0:
+        return render_template("wordnotfound.html"), 404
+    # else, there must be valid letters inside
+
     url = "https://api.dictionaryapi.dev/api/v2/entries/en_US/{}".format(name)
 
     response = requests.get(url)


### PR DESCRIPTION
Internal server error was returned due to the api request of "https://api.dictionaryapi.dev/api/v2/entries/en_US/   " will of course return an error (no words were passed to the API, since it doesn't see blank space in a URL).
So, I added a simple if statement to circumvent this error.